### PR TITLE
Update watchall.js

### DIFF
--- a/watchall.js
+++ b/watchall.js
@@ -188,7 +188,7 @@
 
         // Insert a <yt-attributed-string> child with our text
         // (remove any existing children first, just in case)
-        formattedString.innerHTML = 'Play All';
+        formattedString.textContent = 'Play All';
         formattedString.style.color = 'red';
         formattedString.style.fontWeight = 'bolder';
         const attrString = document.createElement('yt-attributed-string');


### PR DESCRIPTION
fix: resolve TrustedHTML assignment error by removing use of innerHTML

Replaced innerHTML with textContent in finalizeChipContent to comply with YouTube's Trusted Types policy and prevent DOM assignment errors.